### PR TITLE
deprecated linspace replaced with range

### DIFF
--- a/notebooks/usertype_recipes.ipynb
+++ b/notebooks/usertype_recipes.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load in Plots.  Note that RecipesBase is loaded as well,\n",
@@ -17,9 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -36,7 +32,7 @@
     "using Distributions\n",
     "function default_range(dist::Distribution, n = 4)\n",
     "    μ, σ = mean(dist), std(dist)\n",
-    "    linspace(μ - n*σ,μ + n*σ, 100)\n",
+    "    range(μ - n*σ,μ + n*σ, length=100)\n",
     "end\n",
     "dist = Normal(10,50)"
    ]
@@ -44,9 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -74,9 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1041,9 +1033,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1883,9 +1873,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -2973,9 +2961,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4251,9 +4237,7 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -4281,9 +4265,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -5330,17 +5312,17 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 0.4.4",
+   "display_name": "Julia 1.1.0",
    "language": "julia",
-   "name": "julia-0.4"
+   "name": "julia-1.1"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "0.4.4"
+   "version": "1.1.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
The example notebook uses linspace which is deprecated and is replaced with range function.